### PR TITLE
use network uuids

### DIFF
--- a/terragrunt/bootstrap/module/main.tf
+++ b/terragrunt/bootstrap/module/main.tf
@@ -69,7 +69,7 @@ resource "openstack_compute_instance_v2" "inet-dns" {
   user_data    = local.ext_dns_userdata_file == null ? null : data.template_cloudinit_config.cloudinitdns[0].rendered
 
   network {
-    name = "internet"
+    uuid = "${openstack_networking_network_v2.internet.id}"
     fixed_ip_v4 = cidrhost(var.inet_cidr,514)
   }
 
@@ -166,17 +166,17 @@ resource "openstack_compute_instance_v2" "inet-fw" {
   user_data    = local.fw_userdata_file == null ? null : data.template_cloudinit_config.cloudinitinetfw[0].rendered
 
   network {
-    name = "internet"
+    uuid = "${openstack_networking_network_v2.internet.id}"
     fixed_ip_v4 = cidrhost(var.inet_cidr,254)
   }
 
   network {
-    name = "lan"
+    uuid = "${openstack_networking_network_v2.lan.id}"
     fixed_ip_v4 = cidrhost(var.lan_cidr,254)
   }
 
   network {
-    name = "dmz"
+    uuid = "${openstack_networking_network_v2.dmz.id}"
     fixed_ip_v4 = cidrhost(var.dmz_cidr,254)
   }
 
@@ -228,17 +228,17 @@ resource "openstack_compute_instance_v2" "mgmt" {
   user_data    = local.mgmt_userdata_file == null ? null : data.template_cloudinit_config.cloudinitmgmt[0].rendered
 
   network {
-    name = "internet"
+    uuid = "${openstack_networking_network_v2.internet.id}"
     fixed_ip_v4 = local.mgmt_internet_ip
   }
 
   network {
-    name = "lan"
+    uuid = "${openstack_networking_network_v2.lan.id}"
     fixed_ip_v4 = local.mgmt_lan_ip
   }
 
   network {
-    name = "dmz"
+    uuid = "${openstack_networking_network_v2.dmz.id}"
     fixed_ip_v4 = local.mgmt_dmz_ip
   }
 

--- a/terragrunt/videoserver/module/adminpc.tf
+++ b/terragrunt/videoserver/module/adminpc.tf
@@ -4,8 +4,17 @@ locals {
 
 ####################################################################
 #
-# CREATE INSTANCE for "VIDEOSERVER"
+# CREATE INSTANCE for "ADMIN"
 #
+
+data "external" "lan_uuid" {
+  program = ["bash", "./fetch_network_uuid.sh"]
+
+  query = {
+    network_name = "lan"
+  }
+}
+
 data "template_file" "userdata_adminpc" {
   template = "${file("${local.ext_adminpc_userdata_file}")}"
 }
@@ -35,7 +44,7 @@ resource "openstack_compute_instance_v2" "adminpc" {
   user_data    = local.ext_adminpc_userdata_file == null ? null : data.template_cloudinit_config.cloudinitadminpc[0].rendered
 
   network {
-    name = "lan"
+    uuid ="${data.external.lan_uuid.result.uuid}"
     fixed_ip_v4 = cidrhost(var.lan_cidr,222)
   }
 

--- a/terragrunt/videoserver/module/adminpc_variables.tf
+++ b/terragrunt/videoserver/module/adminpc_variables.tf
@@ -6,7 +6,7 @@ variable "adminpc_image" {
 variable "adminpc_flavor" {
   type        = string
   description = "flavor of the adminpc host"
-  default     = "m1.small"
+  default     = "d2-2"
 }
 
 variable "adminpc_userdata" {

--- a/terragrunt/videoserver/module/dnsserver.tf
+++ b/terragrunt/videoserver/module/dnsserver.tf
@@ -6,6 +6,15 @@ locals {
 #
 # CREATE INSTANCE for "DNS-Server"
 #
+
+data "external" "internet_uuid" {
+  program = ["bash", "./fetch_network_uuid.sh"]
+
+  query = {
+    network_name = "internet"
+  }
+}
+
 data "template_file" "userdata_dnsserver" {
   template = "${file("${local.ext_dnsserver_userdata_file}")}"
 }
@@ -35,7 +44,7 @@ resource "openstack_compute_instance_v2" "dnsserver" {
   user_data    = local.ext_dnsserver_userdata_file == null ? null : data.template_cloudinit_config.cloudinitdnsserver[0].rendered
 
   network {
-    name = "internet"
+    uuid = "${data.external.internet_uuid.result.uuid}"
     fixed_ip_v4 = cidrhost(var.inet_cidr,233)
   }
 

--- a/terragrunt/videoserver/module/dnsserver_variables.tf
+++ b/terragrunt/videoserver/module/dnsserver_variables.tf
@@ -6,7 +6,7 @@ variable "dnsserver_image" {
 variable "dnsserver_flavor" {
   type        = string
   description = "flavor of the dnsserver host"
-  default     = "m1.small"
+  default     = "d2-2"
 }
 
 variable "dnsserver_userdata" {

--- a/terragrunt/videoserver/module/fetch_network_uuid.sh
+++ b/terragrunt/videoserver/module/fetch_network_uuid.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Exit if any of the intermediate steps fail
+set -e
+
+# Extract "network_name" arguments from the input into
+# NETWORK_NAME and shell variables.
+# jq will ensure that the values are properly quoted
+# and escaped for consumption by the shell.
+eval "$(jq -r '@sh "NETWORK_NAME=\(.network_name)"')"
+
+# data fetching
+UUID=$(openstack network list --project "$OS_PROJECT_ID" --name "$NETWORK_NAME" -f value -c ID)
+
+# Safely produce a JSON object containing the result value.
+# jq will ensure that the value is properly quoted
+# and escaped to produce a valid JSON string.
+jq -n --arg uuid "$UUID" '{"uuid":$uuid}'

--- a/terragrunt/videoserver/module/videoserver.tf
+++ b/terragrunt/videoserver/module/videoserver.tf
@@ -6,6 +6,15 @@ locals {
 #
 # CREATE INSTANCE for "VIDEOSERVER"
 #
+
+data "external" "dmz_uuid" {
+  program = ["bash", "./fetch_network_uuid.sh"]
+
+  query = {
+    network_name = "dmz"
+  }
+}
+
 data "template_file" "userdata_videoserver" {
   template = "${file("${local.ext_videoserver_userdata_file}")}"
 }
@@ -35,7 +44,7 @@ resource "openstack_compute_instance_v2" "videoserver" {
   user_data    = local.ext_videoserver_userdata_file == null ? null : data.template_cloudinit_config.cloudinitvideoserver[0].rendered
 
   network {
-    name = "dmz"
+    uuid = "${data.external.dmz_uuid.result.uuid}"
     fixed_ip_v4 = cidrhost(var.dmz_cidr,121)
   }
 

--- a/terragrunt/videoserver/module/videoserver_variables.tf
+++ b/terragrunt/videoserver/module/videoserver_variables.tf
@@ -6,7 +6,7 @@ variable "videoserver_image" {
 variable "videoserver_flavor" {
   type        = string
   description = "flavor of the videoserver host"
-  default     = "m1.small"
+  default     = "d2-2"
 }
 
 variable "videoserver_userdata" {

--- a/terragrunt/videoserver/module/webcam.tf
+++ b/terragrunt/videoserver/module/webcam.tf
@@ -6,6 +6,7 @@ locals {
 #
 # CREATE INSTANCE for "Webcam-Server"
 #
+
 data "template_file" "userdata_webcam" {
   template = "${file("${local.ext_webcam_userdata_file}")}"
 }
@@ -35,7 +36,7 @@ resource "openstack_compute_instance_v2" "webcam" {
   user_data    = local.ext_webcam_userdata_file == null ? null : data.template_cloudinit_config.cloudinitwebcam[0].rendered
 
   network {
-    name = "dmz"
+    uuid = "${data.external.dmz_uuid.result.uuid}"
     fixed_ip_v4 = cidrhost(var.dmz_cidr,80)
   }
 

--- a/terragrunt/videoserver/module/webcam_variables.tf
+++ b/terragrunt/videoserver/module/webcam_variables.tf
@@ -6,7 +6,7 @@ variable "webcam_image" {
 variable "webcam_flavor" {
   type        = string
   description = "flavor of the webcam host"
-  default     = "m1.small"
+  default     = "d2-2"
 }
 
 variable "webcam_userdata" {


### PR DESCRIPTION
After migration to new openstack creating Instances with terragrunt fails with `Error: Error trying to get network information from the Network API: More than one network found for name internet` when networks in other projects with the same name exist
![image](https://github.com/user-attachments/assets/e85a9f24-8b4f-45d2-b9e9-5416d04dfc26)

- this PR fixes this issue by using the network uuid instead of the name when creating instances
