### PR TITLE
state repo as env var

### DIFF
--- a/docs/source/installation/configure.rst
+++ b/docs/source/installation/configure.rst
@@ -18,6 +18,7 @@ We also need the Gitlab-user and Gitlab-token to store the OpenTofu state. We st
     echo "" >> .env
     echo "export CR_GITLAB_ACCESS_TOKEN=YOURTOKEN" >> .env
     echo "export GITLAB_USERNAME=YOURUSERNAME" >> .env
+    echo "export GITLAB_STATE_REPOSITORY=YOURSTATEREPO" >> .env
 
 Finally we also need a remote username for ansible:
 

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -11,4 +11,3 @@ remote_state {
     retry_wait_min = "5"
   }
 }
-

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -1,9 +1,9 @@
 remote_state {
   backend = "http"
   config = {
-    address        = "https://git-service.ait.ac.at/api/v4/projects/2197/terraform/state/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}"
-    lock_address   = "https://git-service.ait.ac.at/api/v4/projects/2197/terraform/state/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}/lock"
-    unlock_address = "https://git-service.ait.ac.at/api/v4/projects/2197/terraform/state/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}/lock"
+    address        = "${get_env("GITLAB_STATE_REPOSITORY")}/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}"
+    lock_address   = "${get_env("GITLAB_STATE_REPOSITORY")}/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}/lock"
+    unlock_address = "${get_env("GITLAB_STATE_REPOSITORY")}/${get_env("OS_PROJECT_NAME")}_${get_env("OS_USER_DOMAIN_NAME")}_${path_relative_to_include()}_${basename(get_repo_root())}/lock"
     username       = "${get_env("GITLAB_USERNAME")}"
     password       = "${get_env("CR_GITLAB_ACCESS_TOKEN")}"
     lock_method    = "POST"
@@ -11,3 +11,4 @@ remote_state {
     retry_wait_min = "5"
   }
 }
+


### PR DESCRIPTION
This PR relates to issue #39 
- uses environment variable for terragrunt state repository in terragrunt.hcl file
- updates docs

**Note:**
export this variable in the projects respective rc file (along with gitlab username and token), or in the .env

the new repo for attackbed:
`export GITLAB_STATE_REPOSITORY=https://git-service.ait.ac.at/api/v4/projects/3012/terraform/state`