### PR TITLE
rename aecid-testbed to attackbed, use domains instead of IPs

### DIFF
--- a/ansible/deploy/opensearch/opensearch.yml
+++ b/ansible/deploy/opensearch/opensearch.yml
@@ -13,17 +13,17 @@
     admin_password: "myStrongPassword@123!"
     kibanaserver_password: "Test@6789"
     logstash_password: "Test@456"
-    domain_name: aecid-testbed.local
-    opensearch_hostname: search.aecid-testbed.local
+    domain_name: attackbed.local
+    opensearch_hostname: search.attackbed.local
     opensearch_hosts:
-            search.aecid-testbed.local: 
+            search.attackbed.local: 
               ip: 192.168.100.11
   roles:
     - role: hostname
       vars:
         hostname: search
         hostname_ip: 192.168.100.11
-        hostname_fqdn: search.aecid-testbed.local
+        hostname_fqdn: search.attackbed.local
     - role: opensearch
     - role: opensearch-dashboards
 

--- a/ansible/run/scenario1/templates/scenario_1_a_a.j2
+++ b/ansible/run/scenario1/templates/scenario_1_a_a.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_a_b.j2
+++ b/ansible/run/scenario1/templates/scenario_1_a_b.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_a_c.j2
+++ b/ansible/run/scenario1/templates/scenario_1_a_c.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_b_a.j2
+++ b/ansible/run/scenario1/templates/scenario_1_b_a.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_b_b.j2
+++ b/ansible/run/scenario1/templates/scenario_1_b_b.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_b_c.j2
+++ b/ansible/run/scenario1/templates/scenario_1_b_c.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_c_a.j2
+++ b/ansible/run/scenario1/templates/scenario_1_c_a.j2
@@ -8,7 +8,7 @@ vars:
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
   $ADMIN_SERVER: 10.12.0.222
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_c_b.j2
+++ b/ansible/run/scenario1/templates/scenario_1_c_b.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_c_c.j2
+++ b/ansible/run/scenario1/templates/scenario_1_c_c.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_d_a.j2
+++ b/ansible/run/scenario1/templates/scenario_1_d_a.j2
@@ -8,7 +8,7 @@ vars:
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
   $ADMIN_SERVER: 10.12.0.222
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_d_b.j2
+++ b/ansible/run/scenario1/templates/scenario_1_d_b.j2
@@ -8,7 +8,7 @@ vars:
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
   $ADMIN_SERVER: 10.12.0.222
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_d_c.j2
+++ b/ansible/run/scenario1/templates/scenario_1_d_c.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_e_a.j2
+++ b/ansible/run/scenario1/templates/scenario_1_e_a.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}
@@ -28,7 +28,7 @@ commands:
     metadata:
       techniques: "T1595,T1592.002"
       tactics: "Reconnaissance"
-      technique_name: "Active Scanning,Gather Victim Host Information: Software
+      technique_name: "Active Scanning,Gather Victim Host Information: Software"
 
   - type: shell
     cmd: "nikto -host $SERVER_ADDRESS"

--- a/ansible/run/scenario1/templates/scenario_1_e_b.j2
+++ b/ansible/run/scenario1/templates/scenario_1_e_b.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_e_c.j2
+++ b/ansible/run/scenario1/templates/scenario_1_e_c.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_f_a.j2
+++ b/ansible/run/scenario1/templates/scenario_1_f_a.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_f_b.j2
+++ b/ansible/run/scenario1/templates/scenario_1_f_b.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario1/templates/scenario_1_f_c.j2
+++ b/ansible/run/scenario1/templates/scenario_1_f_c.j2
@@ -7,7 +7,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $DNS_LIST: /usr/local/share/SecLists/Discovery/DNS/subdomains-top1million-5000.txt
   $SSH_KEY: {{sshkey.public_key}}

--- a/ansible/run/scenario2/templates/scenario_2_a_a.j2
+++ b/ansible/run/scenario2/templates/scenario_2_a_a.j2
@@ -8,7 +8,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $SSH_KEY: "{{user_home.stdout}}/.ssh/privesc_key_videoserver"
   $IMPLANTPATH: /tmp/superimplant

--- a/ansible/run/scenario2/templates/scenario_2_a_c.j2
+++ b/ansible/run/scenario2/templates/scenario_2_a_c.j2
@@ -8,7 +8,7 @@ vars:
   $SERVER_ADDRESS: 192.42.0.254
   $ATTACKER_ADDRESS: 192.42.1.174
   $DNS_SERVER: 192.42.0.233
-  $DOMAIN: aecid-testbed.com
+  $DOMAIN: attackbed.com
   $USER: aecid
   $SSH_KEY: "{{user_home.stdout}}/.ssh/privesc_key_videoserver"
   $IMPLANTPATH: /tmp/superimplant

--- a/ansible/run/scenario3/templates/scenario_3_d.j2
+++ b/ansible/run/scenario3/templates/scenario_3_d.j2
@@ -154,7 +154,7 @@ commands:
 
   - type: ssh
     session: foothold
-    cmd: "node 'linuxshare.aecid-testbed.local' {\n  class { 'blah2': }\n}\n"
+    cmd: "node 'linuxshare.attackbed.local' {\n  class { 'blah2': }\n}\n"
     interactive: True
     metadata:
       techniques: "T1072"

--- a/docs/source/installation/logpipeline.rst
+++ b/docs/source/installation/logpipeline.rst
@@ -122,7 +122,7 @@ To check if the connection to OpenSearch is working, we can use curl to send a r
 
 ::
 
-  curl -u admin:myStrongPassword@123! -X GET "https://search.aecid-testbed.local:9200" --cacert /opt/ca.pem
+  curl -u admin:myStrongPassword@123! -X GET "https://search.attackbed.local:9200" --cacert /opt/ca.pem
 
 If a json is returned with opensearch cluster information, the connection was successfully established.
 

--- a/packer/corpdns/playbook/main.yaml
+++ b/packer/corpdns/playbook/main.yaml
@@ -17,20 +17,20 @@
         dnsmasq_systemd_resolved_disable: true
         dnsmasq_config:
               - { name: "logging",  content: "log-queries" }
-              - { name: "host-video",  content: "host-record=video.aecid-testbed.com,192.42.0.254" }
-              - { name: "host-firewall",  content: "host-record=fw.aecid-testbed.com,192.42.0.254" }
-              - { name: "host-domain",  content: "host-record=aecid-testbed.com,192.42.0.254" }
-              - { name: "auth-zone",  content: "auth-zone=aecid-testbed.com,192.42.0.254" }
+              - { name: "host-video",  content: "host-record=video.attackbed.com,192.42.0.254" }
+              - { name: "host-firewall",  content: "host-record=fw.attackbed.com,192.42.0.254" }
+              - { name: "host-domain",  content: "host-record=attackbed.com,192.42.0.254" }
+              - { name: "auth-zone",  content: "auth-zone=attackbed.com,192.42.0.254" }
               - { name: "auth-server",  content: "auth-server=192.42.0.233,,ens3" }
-              - { name: "domain",  content: "domain=aecid-testbed.com" }
-              - { name: "local-domain",  content: "local=/aecid-testbed.com/192.42.0.254" }
+              - { name: "domain",  content: "domain=attackbed.com" }
+              - { name: "local-domain",  content: "local=/attackbed.com/192.42.0.254" }
     - role: filebeat
       vars:
         filebeat_service_enabled: false
         filebeat_output_logstash_enabled: false
         filebeat_output_kafka_enabled: true
         filebeat_output_kafka_hosts:
-          - "kafka.aecid-testbed.local:9092"
+          - "kafka.attackbed.local:9092"
         filebeat_output_kafka_topic: "logs"
         filebeat_template: "filebeatkafka.yml.j2"
         filebeat_inputs:
@@ -46,5 +46,5 @@
     - name: Add kafka host entry in /etc/hosts
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        line: "192.42.0.254 kafka.aecid-testbed.local"
+        line: "192.42.0.254 kafka.attackbed.local"
         state: present

--- a/packer/firewall/playbook/main.yaml
+++ b/packer/firewall/playbook/main.yaml
@@ -3,7 +3,7 @@
   become: true
   vars:
     suricata_interface: [ens5]
-    internal_domain: "aecid-testbed.local"
+    internal_domain: "attackbed.local"
     suricata_home_nets: ["172.17.100.0/24"]
     netflow_enabled: true
     weaklinuxuser_name: "john"
@@ -147,7 +147,7 @@
         filebeat_service_enabled: false
         filebeat_output_kafka_enabled: true
         filebeat_output_kafka_hosts:
-          - "kafka.aecid-testbed.local:9092"
+          - "kafka.attackbed.local:9092"
         filebeat_output_kafka_topic: "logs"
         filebeat_template: "filebeatkafka.yml.j2"
         filebeat_inputs:
@@ -171,5 +171,5 @@
     - name: Add kafka host entry in /etc/hosts
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        line: "192.168.100.10 kafka.aecid-testbed.local"
+        line: "192.168.100.10 kafka.attackbed.local"
         state: present

--- a/packer/kafka/playbook/main.yaml
+++ b/packer/kafka/playbook/main.yaml
@@ -14,7 +14,7 @@
             vars:
                   hostname: kafka
                   hostname_ip: 192.168.100.10
-                  hostname_fqdn: kafka.aecid-testbed.local
+                  hostname_fqdn: kafka.attackbed.local
           - role: aeciduser
             vars:
                   # pass: aecid

--- a/packer/linuxshare/playbook/main.yaml
+++ b/packer/linuxshare/playbook/main.yaml
@@ -13,7 +13,7 @@
             vars:
                   hostname: linuxshare
                   hostname_ip: 192.168.100.23
-                  hostname_fqdn: linuxshare.aecid-testbed.local
+                  hostname_fqdn: linuxshare.attackbed.local
           - role: aeciduser
             vars:
                   # pass: aecid

--- a/packer/logstash/playbook/main.yaml
+++ b/packer/logstash/playbook/main.yaml
@@ -16,7 +16,7 @@
       - logstash-input-beats
       - logstash-filter-multiline
       - logstash-output-opensearch
-    logstash_opensearch_hosts: [ "https://search.aecid-testbed.local:9200" ]
+    logstash_opensearch_hosts: [ "https://search.attackbed.local:9200" ]
     # ca.pem from the opensearch-config
     logstash_opensearch_ca: "/opt/ca.pem"
     logstash_opensearch_user: "admin"
@@ -28,7 +28,7 @@
       - 31-opensearch-output.conf
     logstash_monitor_local_syslog: False
     logstash_kafka_enable: true
-    logstash_kafka_server: "kafka.aecid-testbed.local:9092"
+    logstash_kafka_server: "kafka.attackbed.local:9092"
     logstash_kafka_topics: [ "logs" ]
 
   pre_tasks:
@@ -45,11 +45,11 @@
     - name: Add opensearch to /etc/hosts
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        line: "192.168.100.11 search.aecid-testbed.local"
+        line: "192.168.100.11 search.attackbed.local"
     - name: Add kafka to /etc/hosts
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        line: "192.168.100.10 kafka.aecid-testbed.local"
+        line: "192.168.100.10 kafka.attackbed.local"
 
   roles:
     - role: aeciduser
@@ -64,5 +64,5 @@
       vars:
         hostname: logstash
         hostname_ip: 192.168.100.12
-        hostname_fqdn: logstash.aecid-testbed.local
+        hostname_fqdn: logstash.attackbed.local
     - role: logstash

--- a/packer/opensearch/playbook/main.yaml
+++ b/packer/opensearch/playbook/main.yaml
@@ -14,10 +14,10 @@
     admin_password: "myStrongPassword@123!"
     kibanaserver_password: "Test@6789"
     logstash_password: "Test@456"
-    domain_name: aecid-testbed.local
-    opensearch_hostname: search.aecid-testbed.local
+    domain_name: attackbed.local
+    opensearch_hostname: search.attackbed.local
     opensearch_hosts:
-            search.aecid-testbed.local: 
+            search.attackbed.local: 
               ip: 127.0.0.1
     iac_enable: true
 
@@ -42,13 +42,13 @@
             vars:
               hostname: search
               hostname_ip: 127.0.0.1
-              hostname_fqdn: search.aecid-testbed.local
+              hostname_fqdn: search.attackbed.local
           - role: opensearch
           - role: opensearch-dashboards
   post_tasks:
         - name: Download root-ca.key to local machine
           ansible.builtin.fetch:
-            src: /usr/share/opensearch/config/search.aecid-testbed.local_http.pem
+            src: /usr/share/opensearch/config/search.attackbed.local_http.pem
             dest: ../../logstash/playbook/files/ca.pem
             flat: yes
         # Manually upload ingest pipelines to OpenSearch
@@ -69,8 +69,8 @@
         - name: Upload ingest pipelines to OpenSearch
           command: >
             curl -u {{ os_admin }}:{{ admin_password }}
-            --cacert /usr/share/opensearch/config/search.aecid-testbed.local_http.pem
-            -X PUT "https://search.aecid-testbed.local:9200/_ingest/pipeline/{{ item.path | basename | regex_replace('.json$', '') }}"
+            --cacert /usr/share/opensearch/config/search.attackbed.local_http.pem
+            -X PUT "https://search.attackbed.local:9200/_ingest/pipeline/{{ item.path | basename | regex_replace('.json$', '') }}"
             -H 'Content-Type: application/json'
             --data-binary "@{{ item.path }}"
           loop: "{{ pipeline_files.files }}"

--- a/packer/repository/playbook/main.yaml
+++ b/packer/repository/playbook/main.yaml
@@ -23,7 +23,7 @@
           - role: hostname
             vars:
                   hostname: "puppet"
-                  hostname_fqdn: "puppet.aecid-testbed.local"
+                  hostname_fqdn: "puppet.attackbed.local"
                   hostname_ip: "172.17.100.122"
           - role: aeciduser
             vars:

--- a/packer/videoserver/playbook/main.yaml
+++ b/packer/videoserver/playbook/main.yaml
@@ -74,7 +74,7 @@
               filebeat_service_enabled: false
               filebeat_output_kafka_enabled: true
               filebeat_output_kafka_hosts:
-                - "kafka.aecid-testbed.local:9092"
+                - "kafka.attackbed.local:9092"
               filebeat_output_kafka_topic: "logs"
               filebeat_template: "filebeatkafka.yml.j2"
               filebeat_inputs:

--- a/terragrunt/bootstrap/module/scripts/dns.yml
+++ b/terragrunt/bootstrap/module/scripts/dns.yml
@@ -20,4 +20,4 @@ runcmd:
   - [apt-get, update]
   - [apt-get, install, -y, python3]
   - [apt-get, install, -y, dnsmasq]
-  - echo "server=/aecid-testbed.com/192.42.0.233" > /etc/dnsmasq.d/corpdomain.conf
+  - echo "server=/attackbed.com/192.42.0.233" > /etc/dnsmasq.d/corpdomain.conf


### PR DESCRIPTION
- renames aecid-testbed to attackbed
- use domain names instead of IPs in attacks
- updates documentation accrodingly

-> requires new packer images for inetfw, corpdns, logstash, kafka