### PR TITLE
change url in sources.list to bulsseye backports archive

### DIFF
--- a/packer/videoserver/playbook/main.yaml
+++ b/packer/videoserver/playbook/main.yaml
@@ -8,6 +8,11 @@
   tasks:
     - name: Deactivate ipv6
       ansible.builtin.shell: echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6
+    - name: Switch to archive mirror because of bullseye-backports 
+      ansible.builtin.replace:
+        path: /etc/apt/sources.list
+        regexp: 'deb.debian.org/debian bullseye-backports'
+        replace: 'archive.debian.org/debian bullseye-backports'
   roles:
     - role: debiansnapshot
 


### PR DESCRIPTION
Videoserver couldn't be built anymore because debian archived the bullseye backports mirror - so the URL in /etc/apt/sources.list was changed to reflect that