### PR TITLE
add default value for contact metadata to instances

### DIFF
--- a/terragrunt/attacker/module/variables.tf
+++ b/terragrunt/attacker/module/variables.tf
@@ -6,5 +6,5 @@ variable "sshkey" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }

--- a/terragrunt/bootstrap/module/variables.tf
+++ b/terragrunt/bootstrap/module/variables.tf
@@ -102,5 +102,5 @@ variable "subnet_cidrs" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }

--- a/terragrunt/client/module/variables.tf
+++ b/terragrunt/client/module/variables.tf
@@ -66,6 +66,6 @@ variable "dmz_cidr" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }
 

--- a/terragrunt/docker/module/variables.tf
+++ b/terragrunt/docker/module/variables.tf
@@ -12,5 +12,5 @@ variable "dmz_cidr" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }

--- a/terragrunt/lanturtle/module/variables.tf
+++ b/terragrunt/lanturtle/module/variables.tf
@@ -12,5 +12,5 @@ variable "dmz_cidr" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }

--- a/terragrunt/logging/module/variables.tf
+++ b/terragrunt/logging/module/variables.tf
@@ -12,6 +12,6 @@ variable "lan_cidr" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }
 

--- a/terragrunt/repository/module/variables.tf
+++ b/terragrunt/repository/module/variables.tf
@@ -6,5 +6,5 @@ variable "sshkey" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }

--- a/terragrunt/videoserver/module/variables.tf
+++ b/terragrunt/videoserver/module/variables.tf
@@ -12,5 +12,5 @@ variable "dmz_cidr" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }

--- a/terragrunt/wazuh/module/variables.tf
+++ b/terragrunt/wazuh/module/variables.tf
@@ -12,5 +12,5 @@ variable "lan_cidr" {
 variable "contact" {
   description = "Username of the person responsible for this instance (required for resource tracking)"
   type        = string
-  default = "contact person"
+  default = "unknown contact"
 }


### PR DESCRIPTION
relates to issue #70 

adds a default value to the contact variable for instance metadata, i.e. no enforcing of adding a contact email