### PR TITLE
Include requirement for disableresolved in repository packer

### DIFF
--- a/packer/repository/playbook/requirements.yml
+++ b/packer/repository/playbook/requirements.yml
@@ -50,3 +50,6 @@ roles:
   - src: https://github.com/ait-testbed/atb-ansible-wazuh_agent.git
     version: v0.9.0
     name: wazuh_agent
+  - src: https://github.com/ait-testbed/atb-ansible-disableresolved.git
+    version: v1.0.0
+    name: disableresolved


### PR DESCRIPTION
The requirement for disbaleresolved was missing in the packer playbooks for the repository server. This commit uses the most recent (and only) version.