### PR TITLE
Updated release version for atb-ansible-nextcloudrce

### DIFF
--- a/packer/docker/playbook/requirements.yml
+++ b/packer/docker/playbook/requirements.yml
@@ -15,7 +15,7 @@ roles:
     version: v1.1.0
     name: aecidtools
   - src: https://github.com/ait-testbed/atb-ansible-nextcloudrce.git
-    version: v1.0.4
+    version: v1.1.0
     name: nextcloudrce
   - src: https://github.com/ait-testbed/atb-ansible-vulndockerd.git
     version: v1.0.0


### PR DESCRIPTION
Updated release version for atb-ansible-nextcloudrce including mail settings for nextcloud users admin, bob and alice (see https://github.com/ait-testbed/atb-ansible-nextcloudrce/compare/v1.0.4...v1.1.0) 