### PR TITLE
auto-subscribe and map special-use attributes for standard folders in dovecot

### DIFF
--- a/packer/docker/playbook/requirements.yml
+++ b/packer/docker/playbook/requirements.yml
@@ -15,7 +15,7 @@ roles:
     version: v1.1.0
     name: aecidtools
   - src: https://github.com/ait-testbed/atb-ansible-nextcloudrce.git
-    version: v1.1.0
+    version: v1.1.1
     name: nextcloudrce
   - src: https://github.com/ait-testbed/atb-ansible-vulndockerd.git
     version: v1.0.0

--- a/packer/docker/playbook/templates/dovecot-10-mail.conf.j2
+++ b/packer/docker/playbook/templates/dovecot-10-mail.conf.j2
@@ -3,4 +3,19 @@ first_valid_uid = 103
 
 namespace inbox {
   inbox = yes
+
+  mailbox Drafts {
+    auto = subscribe
+    special_use = \Drafts
+  }
+
+  mailbox Sent {
+    auto = subscribe
+    special_use = \Sent
+  }
+
+  mailbox Trash {
+    auto = subscribe
+    special_use = \Trash
+  }
 }


### PR DESCRIPTION
Added auto = subscribe to Drafts, Sent, and Trash to ensure they are available by default.